### PR TITLE
fix: typo in protected-route

### DIFF
--- a/docs/examples/protected-route.md
+++ b/docs/examples/protected-route.md
@@ -32,12 +32,12 @@ Then, we can create a simple wrapper:
 
 ```ts
 // @/shared/route
-import { chainRoute, RouteInstance, RouteParamsAndQuery } from 'atomic-router';
+import { chainRoute, RouteParams, RouteInstance, RouteParamsAndQuery } from 'atomic-router';
 import { createEvent } from 'effector';
 
 import { $isAuthorized, tokenReceived } from '@/shared/auth';
 
-export function chainAuthorized<Params>(route: RouteInstance<Params>) {
+export function chainAuthorized<Params extends RouteParams>(route: RouteInstance<Params>) {
   const sessionCheckStarted = createEvent<RouteParamsAndQuery<Params>>();
 
   const alreadyAuthorized = sample({


### PR DESCRIPTION
throws a error with typescript@5.4.5
```
Type 'Params' does not satisfy the constraint 'RouteParams'.ts(2344)
lib.ts(6, 33): This type parameter might need an `extends RouteParams` constraint.
```